### PR TITLE
Updated the latest Log4J version

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides
 and an overview of related software regarding the Log4j vulnerability
 (CVE-2021-44228). CISA encourages users and administrators to review the
 [official Apache release](https://logging.apache.org/log4j/2.x/security.html)
-and upgrade to Log4j 2.17.0 or apply the recommended mitigations immediately.
+and upgrade to Log4j 2.17.1 or apply the recommended mitigations immediately.
 
 The information in this repository is provided "as is" for informational
 purposes only and is being assembled and updated by CISA through


### PR DESCRIPTION
## 🗣 Description ##
Bumped log4j latest version thanks to CVE-2021-44832

## 💭 Motivation and context ##
New Log4J version, due to new Moderate CVE affecting Log4j.
Reference: https://www.openwall.com/lists/oss-security/2021/12/28/1
https://logging.apache.org/log4j/2.x/security.html

## 🧪 Testing ##
N/A

## 📷 Screenshots (if appropriate) ##
N/A

## ✅ Pre-approval checklist ##
- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).

## ✅ Pre-merge checklist ##
- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##
- [ ] Add a tag or create a release.
