### PR TITLE
Update the `update_software_list` workflow

### DIFF
--- a/.github/workflows/update_software_list.yml
+++ b/.github/workflows/update_software_list.yml
@@ -68,6 +68,12 @@ jobs:
         run: pip install --upgrade --requirement config/requirements.txt
       - name: Create the branch for test validation
         run: git switch --create ${{ needs.setup.outputs.testing_branch }}
+      - name: Normalize individual cisagov_*.yml files
+        run: |
+          for file in data/cisagov_*yml; do \
+            normalize-yml --cisagov-format "$file" > "$file".tmp; \
+            mv --force "$file".tmp "$file"; \
+          done
       - name: Update the comprehensive cisagov YAML file
         run: normalize-yml --cisagov-format data/cisagov_*.yml > data/cisagov.yml
       - name: Generate a normalized YAML file from all source YAML files
@@ -84,7 +90,7 @@ jobs:
           commit_user_name: ${{ needs.setup.outputs.git_user }}
           commit_user_email: ${{ needs.setup.outputs.git_email }}
           commit_author: ${{ needs.setup.outputs.git_author }}
-          file_pattern: SOFTWARE-LIST.md data/cisagov.yml
+          file_pattern: SOFTWARE-LIST.md data/cisagov*.yml
   merge_list_update:
     runs-on: ubuntu-latest
     needs:

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,1 +1,1 @@
-https://github.com/cisagov/log4j-md-yml/archive/v1.1.0.tar.gz
+https://github.com/cisagov/log4j-md-yml/archive/v1.1.1.tar.gz


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request does the following:
- Update the version of [cisagov/log4j-md-yml](https://github.com/cisagov/log4j-md-yml) from `v1.1.0` to `v1.1.1`.
- Add normalization of the component `cisagov_*.yml` files to the workflow.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The [cisagov/log4j-md-yml@v1.1.1](https://github.com/cisagov/log4j-md-yml/releases/tag/v1.1.1) release contains some important bug fixes and improvements. Additionally to help keep the data consistent we should normalize the component `cisagov_*.yml` files to keep them in a consistent format (that mirrors the resultant `cisagov.yml` file).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I tested these workflow enhancement in [this Actions run in a testing repository](https://github.com/cisagov/github-actions-playground/actions/runs/1741547516).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
